### PR TITLE
Feat/rel alternate probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,9 @@ Run **all** of these before handing work off:
 - `src/shared/resolver.ts` + `src/shared/cache.ts` ➜ handle↔DID resolution with a debounced `DidHandleCache` and inlined retry logic.
 - `src/shared/services.ts` ➜ service registry + destination builders; parsing helpers moved out.
 - `src/shared/options.ts` ➜ minimal options API (`showEmojis`, `strictMode`, `showCacheDebug`) with listener helpers.
+- `src/shared/rel-alternate.ts` ➜ parses `<link rel="alternate" href="at://...">` metadata into canonical `TransformInfo` for Leaflet/WhtWnd-style pages.
 - `src/background/service-worker.ts` ➜ message router plus a lightweight `tabs.onUpdated` listener that precaches DID/handle pairs for any URL `parseInput` understands (all supported services).
+- `src/background/service-worker.ts` also handles `PROBE_PAGE_FOR_AT_URI` (triggered by the popup) by injecting a short DOM scanner via `chrome.scripting`/`activeTab`, caching successful rel-alternate hits in `chrome.storage.session`.
 - `src/popup/*` ➜ DOM-only rendering (no `innerHTML`), Firefox theme via CSS variables, inline cache debug panel.
 - `src/options/*` ➜ simple UI with three toggles; errors revert to the last known good state.
 - Builds via Vite + `@crxjs/vite-plugin`; remember to run all validation commands listed above.
@@ -52,6 +54,8 @@ Update this checklist as items ship; keep it honest.
 - [x] **Options revert bug** (`src/options/options.ts:13-35`): Error handling always reverts to the _initial_ checkbox state, not the last successful save, because the captured `options` object never updates. _Fixed 2025-11-15 by tracking the last persisted values and reverting to those on failures._
 - [ ] **Tooling determinism** (`package.json`): Almost every devDependency is pinned to `"latest"`, which makes CI/CD non-reproducible and has already caused surprise build breaks.
 - [x] **Cache write amplification** (`src/shared/cache.ts:138-205`): Every cache hit triggers a full `chrome.storage.local.set`, risking quota overruns (120 writes/min) and throttled service-worker lifetimes. _Fixed 2025-11-15 by debouncing read-hit persistence while keeping writes synchronous._
+- [x] **Weaver repo limitation** (`src/shared/services.ts`): alpha.weaver.sh only renders single records; profiles with no `rkey` produced dead links. _Fixed 2025-11-15 by requiring `rkey` for Weaver destinations._
+- [x] **Rel-alternate stale cache** (`src/background/service-worker.ts`): Cached “misses” blocked future metadata probes until the tab reloaded. _Fixed 2025-11-15 by skipping cache reuse unless both `info` and `atUri` are present._
 
 _When you clear an item, document the fix (date + PR/commit) here before removing it so future agents see the history._
 
@@ -62,4 +66,5 @@ _When you clear an item, document the fix (date + PR/commit) here before removin
 - Service worker precaches DID/handle pairs again by parsing every completed tab URL and only acting when `parseInput` recognizes a supported service.
 - `retry.ts`, legacy options helpers, and `wormholeDebug` hooks are gone; parser owns service-specific parsing logic.
 - Options include a third “Show cache debug info” toggle; popup shows cache hit/miss status when enabled.
+- Popup now triggers an on-demand rel=alternate probe (via `activeTab` + `chrome.scripting`) so Leaflet-style pages expose AT URIs without needing `<all_urls>` permissions.
 - Remaining backlog: pin dependencies for deterministic builds.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This is a browser extension that provides "wormhole" navigation between differen
 - [frontpage.fyi](https://frontpage.fyi)
 - [boat.kelinci.net](https://boat.kelinci.net)
 - [plc.directory](https://plc.directory)
-- [toolify.blue](https://toolify.blue)
 
 If you'd like to add support for another service, please open an issue or submit a pull request.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -193,6 +193,7 @@ service to equivalent URLs on other services.</p>
 <li><a href="https://deer.social">deer.social</a></li>
 <li><a href="https://bsky.app">bsky.app</a></li>
 <li><a href="https://atp.tools">atp.tools</a></li>
+<li><a href="https://alpha.weaver.sh">alpha.weaver.sh</a></li>
 <li><a href="https://pdsls.dev">pdsls.dev</a></li>
 <li><a href="https://repoview.edavis.dev">repoview.edavis.dev</a></li>
 <li><a href="https://astrolabe.at">astrolabe.at</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -204,7 +204,6 @@ service to equivalent URLs on other services.</p>
 <li><a href="https://frontpage.fyi">frontpage.fyi</a></li>
 <li><a href="https://boat.kelinci.net">boat.kelinci.net</a></li>
 <li><a href="https://plc.directory">plc.directory</a></li>
-<li><a href="https://toolify.blue">toolify.blue</a></li>
 </ul>
 <p>If you’d like to add support for another service, <a href="https://github.com/aliceisjustplaying/at-wormhole-webextension">please open an
 issue or submit a pull request.</a></p>

--- a/planning/2025-11-15-rel-alternate-probe.md
+++ b/planning/2025-11-15-rel-alternate-probe.md
@@ -11,5 +11,7 @@ Detect `at://` links exposed via `<link rel="alternate" href="at://...">` on the
 3. **Service Worker Probe** – add a new `PROBE_PAGE_FOR_AT_URI` handler that runs `chrome.scripting.executeScript` (activeTab gated) to collect the page’s `<head>` HTML, uses the helper to parse it, and caches the best `TransformInfo` in `chrome.storage.session` keyed by tab. _(Done 2025-11-15)_
 4. **Popup Integration** – when loading the popup, fetch the cached probe info (or trigger a fresh probe) and merge it with the existing `parseInput` result; surface clear status text (“Detected via rel=alternate metadata”) so users know why new actions appeared. _(Done 2025-11-15)_
 5. **Destinations & UX polish** – ensure `buildDestinations` already handles AT URIs with collection/rkey; if not, extend it plus add defensive logging, update docs/AGENTS backlog if review or permissions changed. _(Pending)_
+6. **Merge Semantics** – fix `mergeTransformInfo` to treat empty strings correctly (use nullish coalescing for `bskyAppPath`) so the probe result can’t overwrite a valid empty path. _(Done 2025-11-15)_
+7. **URL-aware Probe Cache** – include the page URL in the probe cache so navigating within a tab doesn’t reuse stale rel=alternate data; invalidate entries when the stored URL doesn’t match the current tab URL. _(Done 2025-11-15)_
 
 _Status: in progress_

--- a/planning/2025-11-15-rel-alternate-probe.md
+++ b/planning/2025-11-15-rel-alternate-probe.md
@@ -1,0 +1,15 @@
+# 2025-11-15 rel=alternate AT URI probe
+
+## Goal
+
+Detect `at://` links exposed via `<link rel="alternate" href="at://...">` on the active tab (Leaflet, WhtWnd, etc.) and feed those AT URIs into the popup so users can jump to any supported destination without guessing the handle.
+
+## Plan
+
+1. **Manifest & Types** – add the `scripting` permission, extend shared message types for a probe request/response, and describe the new detection source so later features can refer to it explicitly. _(Done 2025-11-15)_
+2. **Head Scanner Helper** – build a pure helper (e.g., `extractAtUriFromHead(html: string)`) that sanitizes/validates `<link rel="alternate">` tags and returns canonical AT URIs; unit-test with representative Leaflet/WhtWnd markup. _(Done 2025-11-15)_
+3. **Service Worker Probe** – add a new `PROBE_PAGE_FOR_AT_URI` handler that runs `chrome.scripting.executeScript` (activeTab gated) to collect the page’s `<head>` HTML, uses the helper to parse it, and caches the best `TransformInfo` in `chrome.storage.session` keyed by tab. _(Done 2025-11-15)_
+4. **Popup Integration** – when loading the popup, fetch the cached probe info (or trigger a fresh probe) and merge it with the existing `parseInput` result; surface clear status text (“Detected via rel=alternate metadata”) so users know why new actions appeared. _(Done 2025-11-15)_
+5. **Destinations & UX polish** – ensure `buildDestinations` already handles AT URIs with collection/rkey; if not, extend it plus add defensive logging, update docs/AGENTS backlog if review or permissions changed. _(Pending)_
+
+_Status: in progress_

--- a/planning/2025-11-15-remove-toolify.md
+++ b/planning/2025-11-15-remove-toolify.md
@@ -1,0 +1,14 @@
+# 2025-11-15 remove toolify.blue
+
+## Goal
+
+Drop toolify.blue support entirely so the extension no longer offers or parses that destination.
+
+## Plan
+
+1. **Service + Manifest cleanup** – delete the Toolify config from `src/shared/services.ts` and remove its host permission from `public/manifest.json`. _(Done 2025-11-15)_
+2. **Docs + UX copy** – update README/docs supported-service lists to stop advertising toolify. _(Done 2025-11-15)_
+3. **Tests + Parser** – remove Toolify-specific parsing tests/expectations so the suite reflects the new support matrix. _(Done 2025-11-15)_
+4. **Validation** – rerun the required format/lint/typecheck/test/build/web-ext commands. _(Done 2025-11-15)_
+
+_Status: completed_

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -16,7 +16,7 @@
     "512": "images/icon_512.png"
   },
 
-  "permissions": ["activeTab", "storage", "theme"],
+  "permissions": ["activeTab", "storage", "theme", "scripting"],
   "host_permissions": [
     "https://public.api.bsky.app/*",
     "https://plc.directory/*",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -31,7 +31,6 @@
     "https://frontpage.fyi/*",
     "https://boat.kelinci.net/*",
     "https://repoview.edavis.dev/*",
-    "https://toolify.blue/*",
     "https://astrolabe.at/*"
   ],
 

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -18,6 +18,7 @@ interface ProbeCacheEntry {
   atUri: string | null;
   source: ProbeSource | null;
   detectedAt: number;
+  url: string;
 }
 
 async function initializeCache(): Promise<void> {
@@ -89,7 +90,7 @@ function shouldSkipProbe(url?: string): boolean {
   return !(url.startsWith('http://') || url.startsWith('https://'));
 }
 
-async function runRelAlternateProbe(tabId: number): Promise<ProbeCacheEntry | null> {
+async function runRelAlternateProbe(tabId: number, tabUrl?: string): Promise<ProbeCacheEntry | null> {
   try {
     const injectionResults = (await chrome.scripting.executeScript({
       target: { tabId },
@@ -118,6 +119,7 @@ async function runRelAlternateProbe(tabId: number): Promise<ProbeCacheEntry | nu
       atUri: match?.atUri ?? null,
       source: match ? 'rel-alternate' : null,
       detectedAt: Date.now(),
+      url: tabUrl ?? '',
     };
   } catch (error) {
     logError('serviceWorker', error);
@@ -134,18 +136,21 @@ async function handleProbeRequest(tabId: number, tabUrl?: string, force = false)
     try {
       const cached = await getProbeCache(tabId);
       if (cached && Date.now() - cached.detectedAt < PROBE_CACHE_TTL_MS) {
-        if (cached.info && cached.atUri) {
+        if (tabUrl && (!cached.url || cached.url !== tabUrl)) {
+          await clearProbeCache(tabId);
+        } else if (cached.info && cached.atUri) {
           return { info: cached.info, atUri: cached.atUri, source: cached.source, cached: true };
+        } else {
+          // Cached miss - fall through to rerun probe so we don't stick with stale nulls
+          await clearProbeCache(tabId);
         }
-        // Cached miss - fall through to rerun probe so we don't stick with stale nulls
-        await clearProbeCache(tabId);
       }
     } catch (error) {
       logError('serviceWorker', error);
     }
   }
 
-  const fresh = await runRelAlternateProbe(tabId);
+  const fresh = await runRelAlternateProbe(tabId, tabUrl);
   if (fresh?.atUri && fresh.info) {
     try {
       await setProbeCache(tabId, fresh);

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -183,6 +183,11 @@ async function handleProbeRequest(tabId: number, tabUrl?: string, force = false)
       }
       return { info: fresh.info, atUri: fresh.atUri, source: fresh.source, cached: false };
     }
+
+    // We intentionally do not cache negative results (no metadata) so that
+    // future popup opens can re-check the page. This trades a tiny bit of
+    // extra scripting work for avoiding stale "no metadata" responses when
+    // the page content changes without a navigation event.
   }
 
   return { info: null, atUri: null, source: null, cached: false };

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -2,12 +2,23 @@ import { parseInput } from '../shared/parser';
 import { resolveDidToHandle, resolveHandleToDid } from '../shared/resolver';
 import { DidHandleCache } from '../shared/cache';
 import { debugLog, logError } from '../shared/logging';
-import type { SWMessage } from '../shared/types';
+import type { PageProbeResponse, ProbeSource, SWMessage, TransformInfo } from '../shared/types';
+import { extractAtUriFromAlternateLinks, type AlternateLinkCandidate } from '../shared/rel-alternate';
 
 const cache = new DidHandleCache();
 
 // Create initialization promise immediately at module level
 const cacheInitialized = initializeCache();
+
+const PROBE_CACHE_PREFIX = 'pageProbe:';
+const PROBE_CACHE_TTL_MS = 60_000;
+
+interface ProbeCacheEntry {
+  info: TransformInfo | null;
+  atUri: string | null;
+  source: ProbeSource | null;
+  detectedAt: number;
+}
 
 async function initializeCache(): Promise<void> {
   try {
@@ -40,12 +51,128 @@ async function initializeCache(): Promise<void> {
   }
 }
 
+function getSessionStorageArea(): chrome.storage.StorageArea | null {
+  if ('session' in chrome.storage) {
+    return chrome.storage.session;
+  }
+  return null;
+}
+
+async function getProbeCache(tabId: number): Promise<ProbeCacheEntry | null> {
+  const session = getSessionStorageArea();
+  if (!session) return null;
+  const key = `${PROBE_CACHE_PREFIX}${tabId}`;
+  const result: Record<string, unknown> = await session.get(key);
+  const entry = result[key];
+  if (!entry) {
+    return null;
+  }
+  return entry as ProbeCacheEntry;
+}
+
+async function setProbeCache(tabId: number, entry: ProbeCacheEntry): Promise<void> {
+  const session = getSessionStorageArea();
+  if (!session) return;
+  const key = `${PROBE_CACHE_PREFIX}${tabId}`;
+  await session.set({ [key]: entry });
+}
+
+async function clearProbeCache(tabId: number): Promise<void> {
+  const session = getSessionStorageArea();
+  if (!session) return;
+  const key = `${PROBE_CACHE_PREFIX}${tabId}`;
+  await session.remove(key);
+}
+
+function shouldSkipProbe(url?: string): boolean {
+  if (!url) return true;
+  return !(url.startsWith('http://') || url.startsWith('https://'));
+}
+
+async function runRelAlternateProbe(tabId: number): Promise<ProbeCacheEntry | null> {
+  try {
+    const injectionResults = (await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => {
+        const head = document.head;
+        const links = Array.from(head.querySelectorAll('link[rel]'));
+        return links.map((link) => ({
+          rel: link.getAttribute('rel'),
+          href: link.getAttribute('href'),
+          type: link.getAttribute('type'),
+          title: link.getAttribute('title'),
+        }));
+      },
+    })) as chrome.scripting.InjectionResult<AlternateLinkCandidate[]>[];
+
+    const candidates: AlternateLinkCandidate[] = [];
+    for (const result of injectionResults) {
+      if (result.result) {
+        candidates.push(...result.result);
+      }
+    }
+
+    const match = extractAtUriFromAlternateLinks(candidates);
+    return {
+      info: match?.info ?? null,
+      atUri: match?.atUri ?? null,
+      source: match ? 'rel-alternate' : null,
+      detectedAt: Date.now(),
+    };
+  } catch (error) {
+    logError('serviceWorker', error);
+    return null;
+  }
+}
+
+async function handleProbeRequest(tabId: number, tabUrl?: string, force = false): Promise<PageProbeResponse> {
+  if (shouldSkipProbe(tabUrl)) {
+    return { info: null, atUri: null, source: null, cached: false };
+  }
+
+  if (!force) {
+    try {
+      const cached = await getProbeCache(tabId);
+      if (cached && Date.now() - cached.detectedAt < PROBE_CACHE_TTL_MS) {
+        return { info: cached.info, atUri: cached.atUri, source: cached.source, cached: true };
+      }
+    } catch (error) {
+      logError('serviceWorker', error);
+    }
+  }
+
+  const fresh = await runRelAlternateProbe(tabId);
+  if (fresh) {
+    try {
+      await setProbeCache(tabId, fresh);
+    } catch (error) {
+      logError('serviceWorker', error);
+    }
+    return { info: fresh.info, atUri: fresh.atUri, source: fresh.source, cached: false };
+  }
+
+  return { info: null, atUri: null, source: null, cached: false };
+}
+
 // Handle messages from the popup
 const messageListener = (
   request: SWMessage,
   _sender: chrome.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): boolean => {
+  if (request.type === 'PROBE_PAGE_FOR_AT_URI' && typeof request.tabId === 'number') {
+    void (async () => {
+      try {
+        const response = await handleProbeRequest(request.tabId, request.tabUrl, request.force === true);
+        sendResponse(response);
+      } catch (error) {
+        logError('serviceWorker', error);
+        sendResponse({ info: null, atUri: null, source: null, cached: false });
+      }
+    })();
+    return true;
+  }
+
   // UPDATE_CACHE
   if (request.type === 'UPDATE_CACHE' && typeof request.did === 'string' && typeof request.handle === 'string') {
     void (async () => {
@@ -184,6 +311,10 @@ const tabUpdateListener = (_tabId: number, info: chrome.tabs.TabChangeInfo, tab:
 };
 
 chrome.tabs.onUpdated.addListener(tabUpdateListener);
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  void clearProbeCache(tabId).catch((error: unknown) => logError('serviceWorker', error));
+});
 
 async function precacheFromUrl(rawUrl: string): Promise<void> {
   try {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -165,7 +165,7 @@ async function handleProbeRequest(tabId: number, tabUrl?: string, force = false)
         } else if (cached.info && cached.atUri) {
           return { info: cached.info, atUri: cached.atUri, source: cached.source, cached: true };
         } else {
-          return { info: null, atUri: null, source: cached.source ?? null, cached: true };
+          await clearProbeCache(tabId);
         }
       }
     } catch (error) {
@@ -175,16 +175,14 @@ async function handleProbeRequest(tabId: number, tabUrl?: string, force = false)
 
   const fresh = await getOrCreateProbe(tabId, tabUrl);
   if (fresh) {
-    try {
-      await setProbeCache(tabId, fresh);
-    } catch (error) {
-      logError('serviceWorker', error);
-    }
-
     if (fresh.info && fresh.atUri) {
+      try {
+        await setProbeCache(tabId, fresh);
+      } catch (error) {
+        logError('serviceWorker', error);
+      }
       return { info: fresh.info, atUri: fresh.atUri, source: fresh.source, cached: false };
     }
-    return { info: null, atUri: null, source: fresh.source ?? null, cached: false };
   }
 
   return { info: null, atUri: null, source: null, cached: false };

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -12,6 +12,7 @@ const cacheInitialized = initializeCache();
 
 const PROBE_CACHE_PREFIX = 'pageProbe:';
 const PROBE_CACHE_TTL_MS = 60_000;
+const probeInFlight = new Map<string, Promise<ProbeCacheEntry | null>>();
 
 interface ProbeCacheEntry {
   info: TransformInfo | null;
@@ -90,6 +91,29 @@ function shouldSkipProbe(url?: string): boolean {
   return !(url.startsWith('http://') || url.startsWith('https://'));
 }
 
+function getProbeKey(tabId: number, tabUrl?: string): string {
+  return `${tabId}:${tabUrl ?? ''}`;
+}
+
+function getOrCreateProbe(tabId: number, tabUrl?: string): Promise<ProbeCacheEntry | null> {
+  const key = getProbeKey(tabId, tabUrl);
+  const existing = probeInFlight.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const pending = (async () => {
+    try {
+      return await runRelAlternateProbe(tabId, tabUrl);
+    } finally {
+      probeInFlight.delete(key);
+    }
+  })();
+
+  probeInFlight.set(key, pending);
+  return pending;
+}
+
 async function runRelAlternateProbe(tabId: number, tabUrl?: string): Promise<ProbeCacheEntry | null> {
   try {
     const injectionResults = (await chrome.scripting.executeScript({
@@ -141,8 +165,7 @@ async function handleProbeRequest(tabId: number, tabUrl?: string, force = false)
         } else if (cached.info && cached.atUri) {
           return { info: cached.info, atUri: cached.atUri, source: cached.source, cached: true };
         } else {
-          // Cached miss - fall through to rerun probe so we don't stick with stale nulls
-          await clearProbeCache(tabId);
+          return { info: null, atUri: null, source: cached.source ?? null, cached: true };
         }
       }
     } catch (error) {
@@ -150,15 +173,20 @@ async function handleProbeRequest(tabId: number, tabUrl?: string, force = false)
     }
   }
 
-  const fresh = await runRelAlternateProbe(tabId, tabUrl);
-  if (fresh?.atUri && fresh.info) {
+  const fresh = await getOrCreateProbe(tabId, tabUrl);
+  if (fresh) {
     try {
       await setProbeCache(tabId, fresh);
     } catch (error) {
       logError('serviceWorker', error);
     }
-    return { info: fresh.info, atUri: fresh.atUri, source: fresh.source, cached: false };
+
+    if (fresh.info && fresh.atUri) {
+      return { info: fresh.info, atUri: fresh.atUri, source: fresh.source, cached: false };
+    }
+    return { info: null, atUri: null, source: fresh.source ?? null, cached: false };
   }
+
   return { info: null, atUri: null, source: null, cached: false };
 }
 

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -134,7 +134,11 @@ async function handleProbeRequest(tabId: number, tabUrl?: string, force = false)
     try {
       const cached = await getProbeCache(tabId);
       if (cached && Date.now() - cached.detectedAt < PROBE_CACHE_TTL_MS) {
-        return { info: cached.info, atUri: cached.atUri, source: cached.source, cached: true };
+        if (cached.info && cached.atUri) {
+          return { info: cached.info, atUri: cached.atUri, source: cached.source, cached: true };
+        }
+        // Cached miss - fall through to rerun probe so we don't stick with stale nulls
+        await clearProbeCache(tabId);
       }
     } catch (error) {
       logError('serviceWorker', error);
@@ -142,7 +146,7 @@ async function handleProbeRequest(tabId: number, tabUrl?: string, force = false)
   }
 
   const fresh = await runRelAlternateProbe(tabId);
-  if (fresh) {
+  if (fresh?.atUri && fresh.info) {
     try {
       await setProbeCache(tabId, fresh);
     } catch (error) {
@@ -150,7 +154,6 @@ async function handleProbeRequest(tabId: number, tabUrl?: string, force = false)
     }
     return { info: fresh.info, atUri: fresh.atUri, source: fresh.source, cached: false };
   }
-
   return { info: null, atUri: null, source: null, cached: false };
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -72,7 +72,7 @@ ul#dest a:hover {
 }
 
 .metadata-info {
-  font-size: 12px;
+  font-size: 11px;
   text-align: center;
   margin-top: 4px;
   color: #555;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -71,6 +71,13 @@ ul#dest a:hover {
   margin: 6px 0;
 }
 
+.metadata-info {
+  font-size: 12px;
+  text-align: center;
+  margin-top: 4px;
+  color: #555;
+}
+
 #emptyCacheBtn {
   width: auto;
   text-align: center;
@@ -138,6 +145,9 @@ body.firefox-theme hr {
 @media (prefers-color-scheme: dark) {
   .debug-info {
     color: #aaa;
+  }
+  .metadata-info {
+    color: #bbb;
   }
 }
 #controls {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -12,6 +12,7 @@
       <button id="emptyCacheBtn">Empty Handle+DID Cache</button>
     </div>
     <div id="debugInfo" class="debug-info" hidden></div>
+    <div id="metadataInfo" class="metadata-info" hidden></div>
     <script type="module" src="./popup.ts"></script>
   </body>
 </html>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -78,13 +78,15 @@ function mergeTransformInfo(primary: TransformInfo | null, secondary: TransformI
     return secondary;
   }
 
+  const mergedPath = primary.bskyAppPath !== '' ? primary.bskyAppPath : secondary.bskyAppPath;
+
   return {
     atUri: primary.atUri ?? secondary.atUri,
     did: primary.did ?? secondary.did,
     handle: primary.handle ?? secondary.handle,
     rkey: primary.rkey ?? secondary.rkey,
     nsid: primary.nsid ?? secondary.nsid,
-    bskyAppPath: primary.bskyAppPath,
+    bskyAppPath: mergedPath,
   };
 }
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,7 +1,7 @@
 import { parseInput } from '../shared/parser';
 import { buildDestinations } from '../shared/services';
 import { getOptions, getDefaultOptions } from '../shared/options';
-import type { BrowserWithTheme, Destination } from '../shared/types';
+import type { BrowserWithTheme, Destination, PageProbeResponse, TransformInfo } from '../shared/types';
 import { ResultAsync } from 'neverthrow';
 import { runtimeError, type RuntimeError } from '../shared/errors';
 import { debugLog } from '../shared/logging';
@@ -67,6 +67,41 @@ function sendRuntimeMessage<T>(message: unknown): ResultAsync<T, RuntimeError> {
   );
 }
 
+function mergeTransformInfo(primary: TransformInfo | null, secondary: TransformInfo | null): TransformInfo | null {
+  if (!primary && !secondary) {
+    return null;
+  }
+  if (!secondary) {
+    return primary;
+  }
+  if (!primary) {
+    return secondary;
+  }
+
+  return {
+    atUri: primary.atUri ?? secondary.atUri,
+    did: primary.did ?? secondary.did,
+    handle: primary.handle ?? secondary.handle,
+    rkey: primary.rkey ?? secondary.rkey,
+    nsid: primary.nsid ?? secondary.nsid,
+    bskyAppPath: primary.bskyAppPath || secondary.bskyAppPath,
+  };
+}
+
+function requestPageProbe(tabId: number, tabUrl?: string): Promise<PageProbeResponse | null> {
+  return sendRuntimeMessage<PageProbeResponse>({
+    type: 'PROBE_PAGE_FOR_AT_URI',
+    tabId,
+    tabUrl,
+  }).match(
+    (response) => response,
+    (error) => {
+      console.error('PROBE_PAGE_FOR_AT_URI error', error);
+      return null;
+    },
+  );
+}
+
 // Local type for list items
 
 /**
@@ -111,6 +146,7 @@ const domContentLoadedHandler = () => {
     };
 
     const debugInfo = document.getElementById('debugInfo') as HTMLDivElement | null;
+    const metadataInfo = document.getElementById('metadataInfo') as HTMLDivElement | null;
 
     const setDebugInfo = (msg: string): void => {
       if (!debugInfo) return;
@@ -122,6 +158,19 @@ const domContentLoadedHandler = () => {
       debugInfo.hidden = false;
       debugInfo.textContent = msg;
     };
+
+    const setMetadataInfo = (msg: string | null): void => {
+      if (!metadataInfo) return;
+      if (!msg) {
+        metadataInfo.hidden = true;
+        metadataInfo.textContent = '';
+        return;
+      }
+      metadataInfo.hidden = false;
+      metadataInfo.textContent = msg;
+    };
+
+    setMetadataInfo(null);
 
     if (debugInfo) {
       if (options.showCacheDebug) {
@@ -154,7 +203,12 @@ const domContentLoadedHandler = () => {
     // Determine input: payload param or active tab URL
     const payload = new URLSearchParams(location.search).get('payload');
     const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-    const activeUrl = tabs[0]?.url ?? '';
+    let activeTab: chrome.tabs.Tab | null = null;
+    if (tabs.length > 0) {
+      activeTab = tabs[0];
+    }
+    const activeUrl = activeTab?.url ?? '';
+    const activeTabId = activeTab && typeof activeTab.id === 'number' ? activeTab.id : null;
     const raw: string = payload ?? activeUrl;
     debugLog('parsing', 'Processing input:', raw);
     if (!raw) {
@@ -166,15 +220,31 @@ const domContentLoadedHandler = () => {
     void parseResult.match(
       async (info) => {
         debugLog('parsing', 'Parse result:', info);
-        if (!info || (!info.did && !info.handle && !info.atUri)) {
+        let currentInfo = info;
+
+        if (activeTabId !== null) {
+          const probeResponse = await requestPageProbe(activeTabId, activeUrl);
+          if (probeResponse?.info) {
+            currentInfo = mergeTransformInfo(probeResponse.info, currentInfo);
+            if (probeResponse.source === 'rel-alternate') {
+              setMetadataInfo('Found rel=alternate at:// metadata on this page.');
+            }
+          } else {
+            setMetadataInfo(null);
+          }
+        } else {
+          setMetadataInfo(null);
+        }
+
+        if (!currentInfo || (!currentInfo.did && !currentInfo.handle && !currentInfo.atUri)) {
           showStatus('No DID or at:// URI found in current tab.');
           return;
         }
 
-        let ds = buildDestinations(info, options.showEmojis, options.strictMode);
+        let ds = buildDestinations(currentInfo, options.showEmojis, options.strictMode);
         render(ds);
 
-        if (info.did && !info.handle) {
+        if (currentInfo.did && !currentInfo.handle) {
           // Ask SW for a handle (from cache or resolved)
           showStatus('Resolving...');
 
@@ -183,7 +253,7 @@ const domContentLoadedHandler = () => {
             fromCache: boolean;
           }>({
             type: 'GET_HANDLE',
-            did: info.did,
+            did: currentInfo.did,
           }).match(
             (response) => {
               const handle = response.handle;
@@ -206,8 +276,8 @@ const domContentLoadedHandler = () => {
 
           // After attempting to get handle from cache or by fetching:
           if (handleToUse) {
-            info.handle = handleToUse;
-            ds = buildDestinations(info, options.showEmojis, options.strictMode); // Re-build destinations with the handle
+            currentInfo.handle = handleToUse;
+            ds = buildDestinations(currentInfo, options.showEmojis, options.strictMode); // Re-build destinations with the handle
             render(ds); // Re-render the list
           } else {
             // Handle was not obtained. An error status might have already been set.
@@ -219,12 +289,12 @@ const domContentLoadedHandler = () => {
         }
 
         // If we have a handle but no did, resolve DID via SW
-        if (info.handle && !info.did) {
+        if (currentInfo.handle && !currentInfo.did) {
           showStatus('Resolving...');
 
           const { didToUse, errorStatusWasSet } = await sendRuntimeMessage<{ did: string | null; fromCache: boolean }>({
             type: 'GET_DID',
-            handle: info.handle,
+            handle: currentInfo.handle,
           }).match(
             (response) => {
               const did = response.did;
@@ -246,8 +316,8 @@ const domContentLoadedHandler = () => {
           );
 
           if (didToUse) {
-            info.did = didToUse;
-            ds = buildDestinations(info, options.showEmojis, options.strictMode);
+            currentInfo.did = didToUse;
+            ds = buildDestinations(currentInfo, options.showEmojis, options.strictMode);
             render(ds);
           } else if (!ds.length && !errorStatusWasSet) {
             showStatus('No actions available');

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -84,7 +84,7 @@ function mergeTransformInfo(primary: TransformInfo | null, secondary: TransformI
     handle: primary.handle ?? secondary.handle,
     rkey: primary.rkey ?? secondary.rkey,
     nsid: primary.nsid ?? secondary.nsid,
-    bskyAppPath: primary.bskyAppPath || secondary.bskyAppPath,
+    bskyAppPath: primary.bskyAppPath,
   };
 }
 

--- a/src/shared/rel-alternate.ts
+++ b/src/shared/rel-alternate.ts
@@ -1,0 +1,53 @@
+import { canonicalize } from './canonicalizer';
+import type { TransformInfo } from './types';
+
+export interface AlternateLinkCandidate {
+  href?: string | null;
+  rel?: string | null;
+  type?: string | null;
+  title?: string | null;
+}
+
+export interface RelAlternateProbeResult {
+  atUri: string;
+  info: TransformInfo;
+  rel: string | null;
+  type: string | null;
+}
+
+const AT_URI_PREFIX = 'at://';
+
+function hasAlternateRel(rel: string | null | undefined): boolean {
+  if (!rel) return false;
+  return rel
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((token) => token.toLowerCase())
+    .includes('alternate');
+}
+
+export function extractAtUriFromAlternateLinks(links: AlternateLinkCandidate[]): RelAlternateProbeResult | null {
+  for (const link of links) {
+    if (!hasAlternateRel(link.rel)) continue;
+    const href = (link.href ?? '').trim();
+    if (!href.toLowerCase().startsWith(AT_URI_PREFIX)) continue;
+
+    const canonicalResult = canonicalize(href);
+    if (canonicalResult.isErr()) {
+      continue;
+    }
+    const info = canonicalResult.value;
+    if (!info) {
+      continue;
+    }
+
+    return {
+      atUri: info.atUri ?? href,
+      info,
+      rel: link.rel ?? null,
+      type: link.type ?? null,
+    };
+  }
+
+  return null;
+}

--- a/src/shared/services.ts
+++ b/src/shared/services.ts
@@ -60,6 +60,7 @@ const SERVICE_LIST: [string, ServiceConfig][] = [
       name: 'alpha.weaver.sh',
       contentSupport: 'full',
       buildUrl: (info) => (info.atUri ? `https://alpha.weaver.sh/record/${info.atUri}` : null),
+      requiredFields: { rkey: true },
     },
   ],
   [

--- a/src/shared/services.ts
+++ b/src/shared/services.ts
@@ -257,22 +257,6 @@ const SERVICE_LIST: [string, ServiceConfig][] = [
       requiredFields: { plcOnly: true },
     },
   ],
-  [
-    'TOOLIFY_BLUE',
-    {
-      emoji: '🔧',
-      name: 'toolify.blue',
-      contentSupport: 'profiles-and-posts',
-      parsing: {
-        hostname: 'toolify.blue',
-        patterns: {
-          profileIdentifier: /^\/profile\/([^/]+)/,
-        },
-      },
-      buildUrl: (info) => `https://toolify.blue${info.bskyAppPath}`,
-      requiredFields: { plcOnly: true },
-    },
-  ],
 ];
 
 export const SERVICES: Record<string, ServiceConfig> = SERVICE_LIST.reduce<Record<string, ServiceConfig>>(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -16,7 +16,17 @@ export type SWMessage =
   | { type: 'UPDATE_CACHE'; did: string; handle: string }
   | { type: 'GET_HANDLE'; did: string }
   | { type: 'GET_DID'; handle: string }
-  | { type: 'CLEAR_CACHE' };
+  | { type: 'CLEAR_CACHE' }
+  | { type: 'PROBE_PAGE_FOR_AT_URI'; tabId: number; tabUrl?: string; force?: boolean };
+
+export type ProbeSource = 'rel-alternate';
+
+export interface PageProbeResponse {
+  info: TransformInfo | null;
+  atUri: string | null;
+  source: ProbeSource | null;
+  cached: boolean;
+}
 
 export interface Destination {
   url: string;

--- a/tests/rel-alternate.test.ts
+++ b/tests/rel-alternate.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { extractAtUriFromAlternateLinks } from '../src/shared/rel-alternate';
+
+describe('extractAtUriFromAlternateLinks', () => {
+  test('returns first valid AT URI with alternate rel', () => {
+    const result = extractAtUriFromAlternateLinks([
+      { rel: 'stylesheet', href: 'https://example.com/app.css' },
+      { rel: 'alternate', href: 'at://did:plc:example/app.bsky.feed.post/abc' },
+    ]);
+
+    expect(result?.atUri).toEqual('at://did:plc:example/app.bsky.feed.post/abc');
+    expect(result?.info.did).toEqual('did:plc:example');
+    expect(result?.info.nsid).toEqual('app.bsky.feed.post');
+    expect(result?.info.rkey).toEqual('abc');
+  });
+
+  test('ignores entries without alternate rel tokens', () => {
+    const result = extractAtUriFromAlternateLinks([
+      { rel: 'icon', href: 'at://did:plc:example/app.bsky.feed.post/abc' },
+      { rel: 'ALTERNATE next', href: 'https://example.com/not-at' },
+    ]);
+
+    expect(result).toBeNull();
+  });
+
+  test('handles rel tokens with mixed casing and trimmed hrefs', () => {
+    const result = extractAtUriFromAlternateLinks([
+      { rel: 'feed Alternate', href: '  at://did:plc:other/app.bsky.feed.generator/xyz  ' },
+    ]);
+
+    expect(result?.info.did).toEqual('did:plc:other');
+    expect(result?.info.nsid).toEqual('app.bsky.feed.generator');
+    expect(result?.info.rkey).toEqual('xyz');
+  });
+});

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -356,6 +356,13 @@ describe('buildDestinations', () => {
     expect(hasSkythreadUrl).toBe(false);
   });
 
+  test('should exclude alpha.weaver.sh when record key missing', () => {
+    const profileOnlyInfo = { ...realPostInfo, rkey: undefined, nsid: undefined };
+    const destinations = buildDestinations(profileOnlyInfo);
+    const hasWeaver = destinations.some((dest) => dest.label.includes('alpha.weaver.sh'));
+    expect(hasWeaver).toBe(false);
+  });
+
   test('should exclude handle-based services when no handle', () => {
     const didOnlyInfo = { ...realPostInfo, handle: null };
     const destinations = buildDestinations(didOnlyInfo);

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -216,56 +216,6 @@ describe('parseInput', () => {
       });
     });
   });
-
-  describe('toolify.blue URLs', () => {
-    test('should parse profile URL with handle', () => {
-      const result = parseInput('https://toolify.blue/profile/alice.mosphere.at');
-      expect(result._unsafeUnwrap()).toEqual({
-        atUri: 'at://alice.mosphere.at',
-        did: null,
-        handle: 'alice.mosphere.at',
-        rkey: undefined,
-        nsid: undefined,
-        bskyAppPath: '/profile/alice.mosphere.at',
-      });
-    });
-
-    test('should parse post URL with handle', () => {
-      const result = parseInput('https://toolify.blue/profile/alice.mosphere.at/post/3lqeyxrcx6k2p');
-      expect(result._unsafeUnwrap()).toEqual({
-        atUri: 'at://alice.mosphere.at/app.bsky.feed.post/3lqeyxrcx6k2p',
-        did: null,
-        handle: 'alice.mosphere.at',
-        rkey: '3lqeyxrcx6k2p',
-        nsid: 'app.bsky.feed.post',
-        bskyAppPath: '/profile/alice.mosphere.at/post/3lqeyxrcx6k2p',
-      });
-    });
-
-    test('should parse profile URL with DID', () => {
-      const result = parseInput('https://toolify.blue/profile/did:plc:by3jhwdqgbtrcc7q4tkkv3cf');
-      expect(result._unsafeUnwrap()).toEqual({
-        atUri: 'at://did:plc:by3jhwdqgbtrcc7q4tkkv3cf',
-        did: 'did:plc:by3jhwdqgbtrcc7q4tkkv3cf',
-        handle: null,
-        rkey: undefined,
-        nsid: undefined,
-        bskyAppPath: '/profile/did:plc:by3jhwdqgbtrcc7q4tkkv3cf',
-      });
-    });
-
-    test('should parse post URL with DID', () => {
-      const result = parseInput('https://toolify.blue/profile/did:plc:by3jhwdqgbtrcc7q4tkkv3cf/post/3lqeyxrcx6k2p');
-      expect(result._unsafeUnwrap()).toEqual({
-        atUri: 'at://did:plc:by3jhwdqgbtrcc7q4tkkv3cf/app.bsky.feed.post/3lqeyxrcx6k2p',
-        did: 'did:plc:by3jhwdqgbtrcc7q4tkkv3cf',
-        handle: null,
-        rkey: '3lqeyxrcx6k2p',
-        nsid: 'app.bsky.feed.post',
-        bskyAppPath: '/profile/did:plc:by3jhwdqgbtrcc7q4tkkv3cf/post/3lqeyxrcx6k2p',
-      });
-    });
-  });
 });
 
 describe('resolveHandleToDid', () => {
@@ -319,7 +269,6 @@ describe('buildDestinations', () => {
       else if (dest.label.includes('cred.blue')) acc['cred.blue'] = dest.url;
       else if (dest.label.includes('tangled.sh')) acc['tangled.sh'] = dest.url;
       else if (dest.label.includes('frontpage.fyi')) acc['frontpage.fyi'] = dest.url;
-      else if (dest.label.includes('toolify.blue')) acc['toolify.blue'] = dest.url;
       else if (dest.label.includes('boat.kelinci')) acc['boat.kelinci'] = dest.url;
       else if (dest.label.includes('plc.directory')) acc['plc.directory'] = dest.url;
       return acc;
@@ -344,7 +293,6 @@ describe('buildDestinations', () => {
     expect(destMap['cred.blue']).toBe('https://cred.blue/now.alice.mosphere.at');
     expect(destMap['tangled.sh']).toBe('https://tangled.sh/@now.alice.mosphere.at');
     expect(destMap['frontpage.fyi']).toBe('https://frontpage.fyi/profile/now.alice.mosphere.at');
-    expect(destMap['toolify.blue']).toBe('https://toolify.blue/profile/now.alice.mosphere.at/post/3lqcw7n4gly2u');
     expect(destMap['boat.kelinci']).toBe('https://boat.kelinci.net/plc-oplogs?q=did:plc:kkkcb7sys7623hcf7oefcffg');
     expect(destMap['plc.directory']).toBe('https://plc.directory/did:plc:kkkcb7sys7623hcf7oefcffg');
   });
@@ -397,18 +345,6 @@ describe('buildDestinations', () => {
     expect(bskyDestination?.label).toBe('bsky.app');
   });
 
-  test('should include toolify.blue with emoji when showEmojis is true', () => {
-    const destinations = buildDestinations(realPostInfo, true);
-    const toolifyDestination = destinations.find((dest) => dest.url.includes('toolify.blue'));
-    expect(toolifyDestination?.label).toBe('🔧 toolify.blue');
-  });
-
-  test('should include toolify.blue without emoji when showEmojis is false', () => {
-    const destinations = buildDestinations(realPostInfo, false);
-    const toolifyDestination = destinations.find((dest) => dest.url.includes('toolify.blue'));
-    expect(toolifyDestination?.label).toBe('toolify.blue');
-  });
-
   describe('strict mode', () => {
     const postInfo = {
       atUri: 'at://did:plc:kkkcb7sys7623hcf7oefcffg/app.bsky.feed.post/3lqcw7n4gly2u',
@@ -449,7 +385,6 @@ describe('buildDestinations', () => {
 
       // Should include all service types
       expect(destinations.some((d) => d.url.includes('deer.social'))).toBe(true); // full
-      expect(destinations.some((d) => d.url.includes('toolify.blue'))).toBe(true); // profiles-and-posts
       expect(destinations.some((d) => d.url.includes('skythread'))).toBe(true); // only-posts
       expect(destinations.some((d) => d.url.includes('cred.blue'))).toBe(true); // only-profiles (fallback)
     });
@@ -460,7 +395,6 @@ describe('buildDestinations', () => {
       // Should include post-supporting services
       expect(destinations.some((d) => d.url.includes('deer.social'))).toBe(true); // full
       expect(destinations.some((d) => d.url.includes('bsky.app'))).toBe(true); // full
-      expect(destinations.some((d) => d.url.includes('toolify.blue'))).toBe(true); // profiles-and-posts
       expect(destinations.some((d) => d.url.includes('skythread'))).toBe(true); // only-posts
 
       // Should exclude profile-only services
@@ -472,7 +406,7 @@ describe('buildDestinations', () => {
       expect(destinations.some((d) => d.url.includes('plc.directory'))).toBe(false);
     });
 
-    test('should exclude toolify.blue in strict mode for feeds', () => {
+    test('should exclude post-only services in strict mode for feeds', () => {
       const destinations = buildDestinations(feedInfo, true, true);
 
       // Should include full content support services
@@ -481,9 +415,6 @@ describe('buildDestinations', () => {
       expect(destinations.some((d) => d.url.includes('pdsls.dev'))).toBe(true);
       expect(destinations.some((d) => d.url.includes('atp.tools'))).toBe(true);
 
-      // Should exclude toolify.blue (only supports posts, not feeds)
-      expect(destinations.some((d) => d.url.includes('toolify.blue'))).toBe(false);
-
       // Should exclude skythread (only supports posts, not feeds)
       expect(destinations.some((d) => d.url.includes('skythread'))).toBe(false);
 
@@ -491,7 +422,7 @@ describe('buildDestinations', () => {
       expect(destinations.some((d) => d.url.includes('cred.blue'))).toBe(false);
     });
 
-    test('should exclude toolify.blue in strict mode for lists', () => {
+    test('should exclude post-only services in strict mode for lists', () => {
       const destinations = buildDestinations(listInfo, true, true);
 
       // Should include full content support services
@@ -499,9 +430,6 @@ describe('buildDestinations', () => {
       expect(destinations.some((d) => d.url.includes('bsky.app'))).toBe(true);
       expect(destinations.some((d) => d.url.includes('pdsls.dev'))).toBe(true);
       expect(destinations.some((d) => d.url.includes('atp.tools'))).toBe(true);
-
-      // Should exclude toolify.blue (only supports posts, not lists)
-      expect(destinations.some((d) => d.url.includes('toolify.blue'))).toBe(false);
 
       // Should exclude skythread (only supports posts, not lists)
       expect(destinations.some((d) => d.url.includes('skythread'))).toBe(false);
@@ -516,7 +444,6 @@ describe('buildDestinations', () => {
       // Profile viewing should include all services that don't require rkey
       expect(destinations.some((d) => d.url.includes('deer.social'))).toBe(true);
       expect(destinations.some((d) => d.url.includes('bsky.app'))).toBe(true);
-      expect(destinations.some((d) => d.url.includes('toolify.blue'))).toBe(true);
       expect(destinations.some((d) => d.url.includes('cred.blue'))).toBe(true);
       expect(destinations.some((d) => d.url.includes('tangled.sh'))).toBe(true);
       expect(destinations.some((d) => d.url.includes('frontpage.fyi'))).toBe(true);


### PR DESCRIPTION
Implements #10 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an activeTab+scripting rel=alternate metadata probe feeding the popup, drops toolify.blue, requires rkey for alpha.weaver.sh, and updates docs/tests accordingly.
> 
> - **Rel=alternate AT URI probe**
>   - `src/shared/rel-alternate.ts`: new helper to extract canonical AT URIs from `<link rel="alternate">`.
>   - `src/background/service-worker.ts`: handle `PROBE_PAGE_FOR_AT_URI`; injects DOM scanner via `chrome.scripting`, caches positive results in `chrome.storage.session` (URL-aware TTL), clears on tab close.
>   - `src/shared/types.ts`: adds probe message/response types.
>   - `src/popup/popup.ts/html/css`: request probe, merge `TransformInfo`, and show metadata status; small UI additions.
>   - `public/manifest.json`: add `scripting` permission.
> - **Services**
>   - `src/shared/services.ts`: require `rkey` for `alpha.weaver.sh` destinations.
>   - Remove `toolify.blue` (service registry and host permission); purge related expectations.
> - **Tests**
>   - `tests/rel-alternate.test.ts`: new unit tests for metadata extraction.
>   - `tests/transform.test.ts`: update to reflect removal of toolify and weaver `rkey` requirement.
> - **Docs/Planning**
>   - Supported services lists updated (README/docs); `AGENTS.md` and `planning/*` document the probe feature and toolify removal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b5b520d1114c800149d53a1b2324aac8d49d922. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->